### PR TITLE
Update generated tags

### DIFF
--- a/cf.go
+++ b/cf.go
@@ -10,7 +10,6 @@ import (
 
 type NameResolver interface {
 	getOrganizationName(organizationGUID string) (string, error)
-	getServiceInstanceName(instanceGUID string) (string, error)
 	getSpaceName(spaceGUID string) (string, error)
 }
 
@@ -18,18 +17,13 @@ type OrganizationGetter interface {
 	Get(ctx context.Context, guid string) (*resource.Organization, error)
 }
 
-type ServiceInstanceGetter interface {
-	Get(ctx context.Context, guid string) (*resource.ServiceInstance, error)
-}
-
 type SpaceGetter interface {
 	Get(ctx context.Context, guid string) (*resource.Space, error)
 }
 
 type cfNameResolver struct {
-	Organizations    OrganizationGetter
-	ServiceInstances ServiceInstanceGetter
-	Spaces           SpaceGetter
+	Organizations OrganizationGetter
+	Spaces        SpaceGetter
 }
 
 func newCFNameResolver(
@@ -50,18 +44,9 @@ func newCFNameResolver(
 		return nil, err
 	}
 	return &cfNameResolver{
-		Organizations:    cf.Organizations,
-		ServiceInstances: cf.ServiceInstances,
-		Spaces:           cf.Spaces,
+		Organizations: cf.Organizations,
+		Spaces:        cf.Spaces,
 	}, nil
-}
-
-func (c *cfNameResolver) getServiceInstanceName(instanceGUID string) (string, error) {
-	instance, err := c.ServiceInstances.Get(context.Background(), instanceGUID)
-	if err != nil {
-		return "", err
-	}
-	return instance.Name, nil
 }
 
 func (c *cfNameResolver) getOrganizationName(organizationGUID string) (string, error) {

--- a/cf.go
+++ b/cf.go
@@ -11,8 +11,6 @@ import (
 type NameResolver interface {
 	getOrganizationName(organizationGUID string) (string, error)
 	getServiceInstanceName(instanceGUID string) (string, error)
-	getServiceOfferingName(serviceGUID string) (string, error)
-	getServicePlanName(servicePlanGUID string) (string, error)
 	getSpaceName(spaceGUID string) (string, error)
 }
 
@@ -24,14 +22,6 @@ type ServiceInstanceGetter interface {
 	Get(ctx context.Context, guid string) (*resource.ServiceInstance, error)
 }
 
-type ServiceOfferingGetter interface {
-	Get(ctx context.Context, guid string) (*resource.ServiceOffering, error)
-}
-
-type ServicePlanGetter interface {
-	Get(ctx context.Context, guid string) (*resource.ServicePlan, error)
-}
-
 type SpaceGetter interface {
 	Get(ctx context.Context, guid string) (*resource.Space, error)
 }
@@ -39,8 +29,6 @@ type SpaceGetter interface {
 type cfNameResolver struct {
 	Organizations    OrganizationGetter
 	ServiceInstances ServiceInstanceGetter
-	ServiceOfferings ServiceOfferingGetter
-	ServicePlans     ServicePlanGetter
 	Spaces           SpaceGetter
 }
 
@@ -64,8 +52,6 @@ func newCFNameResolver(
 	return &cfNameResolver{
 		Organizations:    cf.Organizations,
 		ServiceInstances: cf.ServiceInstances,
-		ServiceOfferings: cf.ServiceOfferings,
-		ServicePlans:     cf.ServicePlans,
 		Spaces:           cf.Spaces,
 	}, nil
 }
@@ -76,22 +62,6 @@ func (c *cfNameResolver) getServiceInstanceName(instanceGUID string) (string, er
 		return "", err
 	}
 	return instance.Name, nil
-}
-
-func (c *cfNameResolver) getServiceOfferingName(serviceGUID string) (string, error) {
-	service, err := c.ServiceOfferings.Get(context.Background(), serviceGUID)
-	if err != nil {
-		return "", err
-	}
-	return service.Name, nil
-}
-
-func (c *cfNameResolver) getServicePlanName(servicePlanGUID string) (string, error) {
-	servicePlan, err := c.ServicePlans.Get(context.Background(), servicePlanGUID)
-	if err != nil {
-		return "", err
-	}
-	return servicePlan.Name, nil
 }
 
 func (c *cfNameResolver) getOrganizationName(organizationGUID string) (string, error) {

--- a/cf.go
+++ b/cf.go
@@ -2,8 +2,6 @@ package brokertags
 
 import (
 	"context"
-	"fmt"
-	"os"
 
 	"github.com/cloudfoundry-community/go-cfclient/v3/client"
 	"github.com/cloudfoundry-community/go-cfclient/v3/config"
@@ -46,38 +44,15 @@ type cfNameResolver struct {
 	Spaces           SpaceGetter
 }
 
-const (
-	cfApiUrlEnvVar          = "CF_API_URL"
-	cfApiClientIdEnvVar     = "CF_API_CLIENT_ID"
-	cfApiClientSecretEnvVar = "CF_API_CLIENT_SECRET"
-)
-
-func getRequiredEnvVars() (map[string]string, error) {
-	requiredEnvVars := []string{
-		cfApiUrlEnvVar,
-		cfApiClientIdEnvVar,
-		cfApiClientSecretEnvVar,
-	}
-	envVarValues := make(map[string]string)
-	for _, envVarName := range requiredEnvVars {
-		value, exists := os.LookupEnv(envVarName)
-		if !exists {
-			return nil, fmt.Errorf("%s environment variable is required", envVarName)
-		}
-		envVarValues[envVarName] = value
-	}
-	return envVarValues, nil
-}
-
-func newCFNameResolver() (*cfNameResolver, error) {
-	envVars, err := getRequiredEnvVars()
-	if err != nil {
-		return nil, err
-	}
+func newCFNameResolver(
+	cfApiUrl string,
+	cfApiClientId string,
+	cfApiClientSecret string,
+) (*cfNameResolver, error) {
 	cfg, err := config.NewClientSecret(
-		envVars[cfApiUrlEnvVar],
-		envVars[cfApiClientIdEnvVar],
-		envVars[cfApiClientSecretEnvVar],
+		cfApiUrl,
+		cfApiClientId,
+		cfApiClientSecret,
 	)
 	if err != nil {
 		return nil, err

--- a/cf_test.go
+++ b/cf_test.go
@@ -45,42 +45,6 @@ func (si *mockServiceInstances) Get(ctx context.Context, guid string) (*resource
 	}, nil
 }
 
-type mockServiceOfferings struct {
-	getServiceOfferingErr error
-	serviceOfferingName   string
-	serviceOfferingGuid   string
-}
-
-func (so *mockServiceOfferings) Get(ctx context.Context, guid string) (*resource.ServiceOffering, error) {
-	if so.getServiceOfferingErr != nil {
-		return nil, so.getServiceOfferingErr
-	}
-	if guid != so.serviceOfferingGuid {
-		return nil, fmt.Errorf("guid argument: %s does not match expected guid: %s", guid, so.serviceOfferingGuid)
-	}
-	return &resource.ServiceOffering{
-		Name: so.serviceOfferingName,
-	}, nil
-}
-
-type mockServicePlans struct {
-	getServicePlanErr error
-	servicePlanName   string
-	servicePlanGuid   string
-}
-
-func (sp *mockServicePlans) Get(ctx context.Context, guid string) (*resource.ServicePlan, error) {
-	if sp.getServicePlanErr != nil {
-		return nil, sp.getServicePlanErr
-	}
-	if guid != sp.servicePlanGuid {
-		return nil, fmt.Errorf("guid argument: %s does not match expected guid: %s", guid, sp.servicePlanGuid)
-	}
-	return &resource.ServicePlan{
-		Name: sp.servicePlanName,
-	}, nil
-}
-
 type mockSpaces struct {
 	getSpaceErr error
 	spaceName   string
@@ -113,8 +77,6 @@ func TestGetOrganizationName(t *testing.T) {
 					organizationGuid: "guid-1",
 				},
 				ServiceInstances: &mockServiceInstances{},
-				ServiceOfferings: &mockServiceOfferings{},
-				ServicePlans:     &mockServicePlans{},
 				Spaces:           &mockSpaces{},
 			},
 			organizationGuid:         "guid-1",
@@ -126,9 +88,7 @@ func TestGetOrganizationName(t *testing.T) {
 				ServiceInstances: &mockServiceInstances{
 					getServiceInstanceErr: errors.New("error getting organization"),
 				},
-				ServiceOfferings: &mockServiceOfferings{},
-				ServicePlans:     &mockServicePlans{},
-				Spaces:           &mockSpaces{},
+				Spaces: &mockSpaces{},
 			},
 			expectedErr: errors.New("error getting organization"),
 		},
@@ -161,9 +121,7 @@ func TestGetServiceInstanceName(t *testing.T) {
 					serviceInstanceName: "instance-1",
 					serviceInstanceGuid: "guid-1",
 				},
-				ServiceOfferings: &mockServiceOfferings{},
-				ServicePlans:     &mockServicePlans{},
-				Spaces:           &mockSpaces{},
+				Spaces: &mockSpaces{},
 			},
 			serviceInstanceGuid:  "guid-1",
 			expectedInstanceName: "instance-1",
@@ -174,9 +132,7 @@ func TestGetServiceInstanceName(t *testing.T) {
 				ServiceInstances: &mockServiceInstances{
 					getServiceInstanceErr: errors.New("error getting service instance"),
 				},
-				ServiceOfferings: &mockServiceOfferings{},
-				ServicePlans:     &mockServicePlans{},
-				Spaces:           &mockSpaces{},
+				Spaces: &mockSpaces{},
 			},
 			expectedErr: errors.New("error getting service instance"),
 		},
@@ -187,102 +143,6 @@ func TestGetServiceInstanceName(t *testing.T) {
 			offeringName, err := test.cfClientWrapper.getServiceInstanceName(test.serviceInstanceGuid)
 			if offeringName != test.expectedInstanceName {
 				t.Fatalf("expected instance name: %s, got: %s", test.expectedInstanceName, offeringName)
-			}
-			if err != nil && err.Error() != test.expectedErr.Error() {
-				t.Fatalf("expected error: %s, got: %s", test.expectedErr, err)
-			}
-		})
-	}
-}
-
-func TestGetServiceOfferingName(t *testing.T) {
-	testCases := map[string]struct {
-		cfClientWrapper      *cfNameResolver
-		expectedOfferingName string
-		expectedErr          error
-		serviceOfferingGuid  string
-	}{
-		"success": {
-			cfClientWrapper: &cfNameResolver{
-				Organizations:    &mockOrganizations{},
-				ServiceInstances: &mockServiceInstances{},
-				ServiceOfferings: &mockServiceOfferings{
-					serviceOfferingName: "offering-1",
-					serviceOfferingGuid: "guid-1",
-				},
-				ServicePlans: &mockServicePlans{},
-				Spaces:       &mockSpaces{},
-			},
-			serviceOfferingGuid:  "guid-1",
-			expectedOfferingName: "offering-1",
-		},
-		"error": {
-			cfClientWrapper: &cfNameResolver{
-				Organizations:    &mockOrganizations{},
-				ServiceInstances: &mockServiceInstances{},
-				ServiceOfferings: &mockServiceOfferings{
-					getServiceOfferingErr: errors.New("error getting service offering"),
-				},
-				ServicePlans: &mockServicePlans{},
-				Spaces:       &mockSpaces{},
-			},
-			expectedErr: errors.New("error getting service offering"),
-		},
-	}
-
-	for name, test := range testCases {
-		t.Run(name, func(t *testing.T) {
-			offeringName, err := test.cfClientWrapper.getServiceOfferingName(test.serviceOfferingGuid)
-			if offeringName != test.expectedOfferingName {
-				t.Fatalf("expected offering name: %s, got: %s", test.expectedOfferingName, offeringName)
-			}
-			if err != nil && err.Error() != test.expectedErr.Error() {
-				t.Fatalf("expected error: %s, got: %s", test.expectedErr, err)
-			}
-		})
-	}
-}
-
-func TestGetServicePlanName(t *testing.T) {
-	testCases := map[string]struct {
-		cfClientWrapper  *cfNameResolver
-		expectedPlanName string
-		expectedErr      error
-		servicePlanGuid  string
-	}{
-		"success": {
-			cfClientWrapper: &cfNameResolver{
-				Organizations:    &mockOrganizations{},
-				ServiceInstances: &mockServiceInstances{},
-				ServiceOfferings: &mockServiceOfferings{},
-				ServicePlans: &mockServicePlans{
-					servicePlanName: "plan-1",
-					servicePlanGuid: "guid-1",
-				},
-				Spaces: &mockSpaces{},
-			},
-			servicePlanGuid:  "guid-1",
-			expectedPlanName: "plan-1",
-		},
-		"error": {
-			cfClientWrapper: &cfNameResolver{
-				Organizations:    &mockOrganizations{},
-				ServiceInstances: &mockServiceInstances{},
-				ServiceOfferings: &mockServiceOfferings{},
-				ServicePlans: &mockServicePlans{
-					getServicePlanErr: errors.New("error getting service plan"),
-				},
-				Spaces: &mockSpaces{},
-			},
-			expectedErr: errors.New("error getting service plan"),
-		},
-	}
-
-	for name, test := range testCases {
-		t.Run(name, func(t *testing.T) {
-			planName, err := test.cfClientWrapper.getServicePlanName(test.servicePlanGuid)
-			if planName != test.expectedPlanName {
-				t.Fatalf("expected plan name: %s, got: %s", test.expectedPlanName, planName)
 			}
 			if err != nil && err.Error() != test.expectedErr.Error() {
 				t.Fatalf("expected error: %s, got: %s", test.expectedErr, err)
@@ -302,8 +162,6 @@ func TestGetSpaceName(t *testing.T) {
 			cfClientWrapper: &cfNameResolver{
 				Organizations:    &mockOrganizations{},
 				ServiceInstances: &mockServiceInstances{},
-				ServiceOfferings: &mockServiceOfferings{},
-				ServicePlans:     &mockServicePlans{},
 				Spaces: &mockSpaces{
 					spaceName: "plan-1",
 					spaceGuid: "guid-1",
@@ -316,8 +174,6 @@ func TestGetSpaceName(t *testing.T) {
 			cfClientWrapper: &cfNameResolver{
 				Organizations:    &mockOrganizations{},
 				ServiceInstances: &mockServiceInstances{},
-				ServiceOfferings: &mockServiceOfferings{},
-				ServicePlans:     &mockServicePlans{},
 				Spaces: &mockSpaces{
 					getSpaceErr: errors.New("error getting space"),
 				},

--- a/cf_test.go
+++ b/cf_test.go
@@ -27,24 +27,6 @@ func (o *mockOrganizations) Get(ctx context.Context, guid string) (*resource.Org
 	}, nil
 }
 
-type mockServiceInstances struct {
-	getServiceInstanceErr error
-	serviceInstanceName   string
-	serviceInstanceGuid   string
-}
-
-func (si *mockServiceInstances) Get(ctx context.Context, guid string) (*resource.ServiceInstance, error) {
-	if si.getServiceInstanceErr != nil {
-		return nil, si.getServiceInstanceErr
-	}
-	if guid != si.serviceInstanceGuid {
-		return nil, fmt.Errorf("guid argument: %s does not match expected guid: %s", guid, si.serviceInstanceGuid)
-	}
-	return &resource.ServiceInstance{
-		Name: si.serviceInstanceName,
-	}, nil
-}
-
 type mockSpaces struct {
 	getSpaceErr error
 	spaceName   string
@@ -76,8 +58,7 @@ func TestGetOrganizationName(t *testing.T) {
 					organizationName: "org-1",
 					organizationGuid: "guid-1",
 				},
-				ServiceInstances: &mockServiceInstances{},
-				Spaces:           &mockSpaces{},
+				Spaces: &mockSpaces{},
 			},
 			organizationGuid:         "guid-1",
 			expectedOrganizationName: "org-1",
@@ -85,10 +66,7 @@ func TestGetOrganizationName(t *testing.T) {
 		"error": {
 			cfClientWrapper: &cfNameResolver{
 				Organizations: &mockOrganizations{},
-				ServiceInstances: &mockServiceInstances{
-					getServiceInstanceErr: errors.New("error getting organization"),
-				},
-				Spaces: &mockSpaces{},
+				Spaces:        &mockSpaces{},
 			},
 			expectedErr: errors.New("error getting organization"),
 		},
@@ -107,50 +85,6 @@ func TestGetOrganizationName(t *testing.T) {
 	}
 }
 
-func TestGetServiceInstanceName(t *testing.T) {
-	testCases := map[string]struct {
-		cfClientWrapper      *cfNameResolver
-		expectedInstanceName string
-		expectedErr          error
-		serviceInstanceGuid  string
-	}{
-		"success": {
-			cfClientWrapper: &cfNameResolver{
-				Organizations: &mockOrganizations{},
-				ServiceInstances: &mockServiceInstances{
-					serviceInstanceName: "instance-1",
-					serviceInstanceGuid: "guid-1",
-				},
-				Spaces: &mockSpaces{},
-			},
-			serviceInstanceGuid:  "guid-1",
-			expectedInstanceName: "instance-1",
-		},
-		"error": {
-			cfClientWrapper: &cfNameResolver{
-				Organizations: &mockOrganizations{},
-				ServiceInstances: &mockServiceInstances{
-					getServiceInstanceErr: errors.New("error getting service instance"),
-				},
-				Spaces: &mockSpaces{},
-			},
-			expectedErr: errors.New("error getting service instance"),
-		},
-	}
-
-	for name, test := range testCases {
-		t.Run(name, func(t *testing.T) {
-			offeringName, err := test.cfClientWrapper.getServiceInstanceName(test.serviceInstanceGuid)
-			if offeringName != test.expectedInstanceName {
-				t.Fatalf("expected instance name: %s, got: %s", test.expectedInstanceName, offeringName)
-			}
-			if err != nil && err.Error() != test.expectedErr.Error() {
-				t.Fatalf("expected error: %s, got: %s", test.expectedErr, err)
-			}
-		})
-	}
-}
-
 func TestGetSpaceName(t *testing.T) {
 	testCases := map[string]struct {
 		cfClientWrapper   *cfNameResolver
@@ -160,8 +94,7 @@ func TestGetSpaceName(t *testing.T) {
 	}{
 		"success": {
 			cfClientWrapper: &cfNameResolver{
-				Organizations:    &mockOrganizations{},
-				ServiceInstances: &mockServiceInstances{},
+				Organizations: &mockOrganizations{},
 				Spaces: &mockSpaces{
 					spaceName: "plan-1",
 					spaceGuid: "guid-1",
@@ -172,8 +105,7 @@ func TestGetSpaceName(t *testing.T) {
 		},
 		"error": {
 			cfClientWrapper: &cfNameResolver{
-				Organizations:    &mockOrganizations{},
-				ServiceInstances: &mockServiceInstances{},
+				Organizations: &mockOrganizations{},
 				Spaces: &mockSpaces{
 					getSpaceErr: errors.New("error getting space"),
 				},

--- a/tags.go
+++ b/tags.go
@@ -12,7 +12,6 @@ const (
 	OrganizationGUIDTagKey    = "Organization GUID"
 	OrganizationNameTagKey    = "Organization name"
 	ServiceInstanceGUIDTagKey = "Instance GUID"
-	ServiceInstanceNameTagKey = "Instance name"
 	ServiceNameTagKey         = "Service offering name"
 	ServicePlanName           = "Service plan name"
 	SpaceGUIDTagKey           = "Space GUID"
@@ -109,12 +108,6 @@ func (t *CfTagManager) GenerateTags(
 
 	if instanceGUID != "" {
 		tags[ServiceInstanceGUIDTagKey] = instanceGUID
-
-		instanceName, err := t.cfNameResolver.getServiceInstanceName(instanceGUID)
-		if err != nil {
-			return nil, err
-		}
-		tags[ServiceInstanceNameTagKey] = instanceName
 	}
 
 	return tags, nil

--- a/tags.go
+++ b/tags.go
@@ -22,6 +22,7 @@ const (
 type TagManager interface {
 	GenerateTags(
 		action Action,
+		environment string,
 		serviceGUID string,
 		servicePlanGUID string,
 		organizationGUID string,

--- a/tags.go
+++ b/tags.go
@@ -24,8 +24,16 @@ type TagManager struct {
 	cfNameResolver NameResolver
 }
 
-func NewManager() (*TagManager, error) {
-	cfNameResolver, err := newCFNameResolver()
+func NewManager(
+	cfApiUrl string,
+	cfApiClientId string,
+	cfApiClientSecret string,
+) (*TagManager, error) {
+	cfNameResolver, err := newCFNameResolver(
+		cfApiUrl,
+		cfApiClientId,
+		cfApiClientSecret,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/tags.go
+++ b/tags.go
@@ -90,7 +90,7 @@ func (t *CfTagManager) GenerateTags(
 	if spaceGUID != "" {
 		tags[SpaceGUIDTagKey] = spaceGUID
 
-		spaceName, err := t.cfNameResolver.getSpaceName(organizationGUID)
+		spaceName, err := t.cfNameResolver.getSpaceName(spaceGUID)
 		if err != nil {
 			return nil, err
 		}

--- a/tags.go
+++ b/tags.go
@@ -13,8 +13,8 @@ const (
 	OrganizationNameTagKey    = "Organization name"
 	ServiceInstanceGUIDTagKey = "Instance GUID"
 	ServiceInstanceNameTagKey = "Instance name"
-	ServiceIDTagKey           = "Service ID"
-	ServicePlanIdTagKey       = "Plan ID"
+	ServiceNameTagKey         = "Service offering name"
+	ServicePlanName           = "Service plan name"
 	SpaceGUIDTagKey           = "Space GUID"
 	SpaceNameTagKey           = "Space name"
 )
@@ -23,8 +23,8 @@ type TagManager interface {
 	GenerateTags(
 		action Action,
 		environment string,
-		serviceGUID string,
-		servicePlanGUID string,
+		serviceName string,
+		servicePlanName string,
 		organizationGUID string,
 		spaceGUID string,
 		instanceGUID string,
@@ -59,8 +59,8 @@ func NewCFTagManager(
 func (t *CfTagManager) GenerateTags(
 	action Action,
 	environment string,
-	serviceID string,
-	planID string,
+	serviceName string,
+	planName string,
 	organizationGUID string,
 	spaceGUID string,
 	instanceGUID string,
@@ -69,18 +69,22 @@ func (t *CfTagManager) GenerateTags(
 
 	tags[ClientTagKey] = "Cloud Foundry"
 
-	tags[BrokerTagKey] = t.broker
-
-	tags[EnvironmentTagKey] = strings.ToLower(environment)
-
 	tags[action.getTagKey()] = time.Now().Format(time.RFC3339)
 
-	if serviceID != "" {
-		tags[ServiceIDTagKey] = serviceID
+	if t.broker != "" {
+		tags[BrokerTagKey] = t.broker
 	}
 
-	if planID != "" {
-		tags[ServicePlanIdTagKey] = planID
+	if environment != "" {
+		tags[EnvironmentTagKey] = strings.ToLower(environment)
+	}
+
+	if serviceName != "" {
+		tags[ServiceNameTagKey] = serviceName
+	}
+
+	if planName != "" {
+		tags[ServicePlanName] = planName
 	}
 
 	if organizationGUID != "" {

--- a/tags.go
+++ b/tags.go
@@ -1,12 +1,14 @@
 package brokertags
 
 import (
+	"strings"
 	"time"
 )
 
 const (
 	BrokerTagKey              = "broker"
 	ClientTagKey              = "client"
+	EnvironmentTagKey         = "environment"
 	OrganizationGUIDTagKey    = "Organization GUID"
 	OrganizationNameTagKey    = "Organization name"
 	ServiceInstanceGUIDTagKey = "Instance GUID"
@@ -55,6 +57,7 @@ func NewCFTagManager(
 
 func (t *CfTagManager) GenerateTags(
 	action Action,
+	environment string,
 	serviceID string,
 	planID string,
 	organizationGUID string,
@@ -66,6 +69,8 @@ func (t *CfTagManager) GenerateTags(
 	tags[ClientTagKey] = "Cloud Foundry"
 
 	tags[BrokerTagKey] = t.broker
+
+	tags[EnvironmentTagKey] = strings.ToLower(environment)
 
 	tags[action.getTagKey()] = time.Now().Format(time.RFC3339)
 

--- a/tags.go
+++ b/tags.go
@@ -19,6 +19,17 @@ const (
 	SpaceNameTagKey           = "Space name"
 )
 
+type TagGenerator interface {
+	GenerateTags(
+		action Action,
+		serviceGUID string,
+		servicePlanGUID string,
+		organizationGUID string,
+		spaceGUID string,
+		instanceGUID string,
+	) (map[string]string, error)
+}
+
 type TagManager struct {
 	broker         string
 	cfNameResolver NameResolver

--- a/tags_test.go
+++ b/tags_test.go
@@ -12,8 +12,6 @@ type mockCFClientWrapper struct {
 	organizationName   string
 	getSpaceErr        error
 	spaceName          string
-	getInstanceErr     error
-	instanceName       string
 	spaceGUID          string
 	organizationGUID   string
 	instanceGUID       string
@@ -37,16 +35,6 @@ func (m *mockCFClientWrapper) getSpaceName(spaceGUID string) (string, error) {
 		return "", errors.New("space GUID does not match expected value")
 	}
 	return m.spaceName, nil
-}
-
-func (m *mockCFClientWrapper) getServiceInstanceName(instanceGUID string) (string, error) {
-	if m.getInstanceErr != nil {
-		return "", m.getInstanceErr
-	}
-	if m.instanceGUID != "" && m.instanceGUID != instanceGUID {
-		return "", errors.New("instance GUID does not match expected value")
-	}
-	return m.instanceName, nil
 }
 
 func TestGenerateTags(t *testing.T) {
@@ -74,7 +62,6 @@ func TestGenerateTags(t *testing.T) {
 				cfNameResolver: &mockCFClientWrapper{
 					organizationName: "org-1",
 					spaceName:        "space-1",
-					instanceName:     "instance-1",
 					spaceGUID:        "abc4",
 					organizationGUID: "abc3",
 					instanceGUID:     "abc5",
@@ -91,7 +78,6 @@ func TestGenerateTags(t *testing.T) {
 				"Instance GUID":         "abc5",
 				"Organization name":     "org-1",
 				"Space name":            "space-1",
-				"Instance name":         "instance-1",
 			},
 		},
 		"Update": {
@@ -107,7 +93,6 @@ func TestGenerateTags(t *testing.T) {
 				cfNameResolver: &mockCFClientWrapper{
 					organizationName: "org-1",
 					spaceName:        "space-1",
-					instanceName:     "instance-1",
 					spaceGUID:        "abc4",
 					organizationGUID: "abc3",
 					instanceGUID:     "abc5",
@@ -124,7 +109,6 @@ func TestGenerateTags(t *testing.T) {
 				"Instance GUID":         "abc5",
 				"Organization name":     "org-1",
 				"Space name":            "space-1",
-				"Instance name":         "instance-1",
 			},
 		},
 		"no broker name": {
@@ -139,7 +123,6 @@ func TestGenerateTags(t *testing.T) {
 				cfNameResolver: &mockCFClientWrapper{
 					organizationName: "org-1",
 					spaceName:        "space-1",
-					instanceName:     "instance-1",
 					spaceGUID:        "abc4",
 					organizationGUID: "abc3",
 					instanceGUID:     "abc5",
@@ -154,7 +137,6 @@ func TestGenerateTags(t *testing.T) {
 				"Instance GUID":         "abc5",
 				"Organization name":     "org-1",
 				"Space name":            "space-1",
-				"Instance name":         "instance-1",
 			},
 		},
 		"no environment tag": {
@@ -170,7 +152,6 @@ func TestGenerateTags(t *testing.T) {
 				cfNameResolver: &mockCFClientWrapper{
 					organizationName: "org-1",
 					spaceName:        "space-1",
-					instanceName:     "instance-1",
 					spaceGUID:        "abc4",
 					organizationGUID: "abc3",
 					instanceGUID:     "abc5",
@@ -186,7 +167,6 @@ func TestGenerateTags(t *testing.T) {
 				"Instance GUID":         "abc5",
 				"Organization name":     "org-1",
 				"Space name":            "space-1",
-				"Instance name":         "instance-1",
 			},
 		},
 	}
@@ -241,15 +221,6 @@ func TestGenerateTagsHandleErrors(t *testing.T) {
 				},
 			},
 			expectedErr: errors.New("error getting space name"),
-		},
-		"error getting instance name": {
-			tagManager: &CfTagManager{
-				broker: "AWS Broker",
-				cfNameResolver: &mockCFClientWrapper{
-					getInstanceErr: errors.New("error getting instance name"),
-				},
-			},
-			expectedErr: errors.New("error getting instance name"),
 		},
 	}
 

--- a/tags_test.go
+++ b/tags_test.go
@@ -51,24 +51,24 @@ func (m *mockCFClientWrapper) getServiceInstanceName(instanceGUID string) (strin
 
 func TestGenerateTags(t *testing.T) {
 	testCases := map[string]struct {
-		tagManager       *CfTagManager
-		expectedTags     map[string]string
-		action           Action
-		environment      string
-		serviceID        string
-		servicePlanID    string
-		organizationGUID string
-		spaceGUID        string
-		instanceGUID     string
+		tagManager          *CfTagManager
+		expectedTags        map[string]string
+		action              Action
+		environment         string
+		serviceOfferingName string
+		servicePlanName     string
+		organizationGUID    string
+		spaceGUID           string
+		instanceGUID        string
 	}{
 		"Create": {
-			action:           Create,
-			serviceID:        "abc1",
-			servicePlanID:    "abc2",
-			organizationGUID: "abc3",
-			spaceGUID:        "abc4",
-			instanceGUID:     "abc5",
-			environment:      "testing",
+			action:              Create,
+			serviceOfferingName: "abc1",
+			servicePlanName:     "abc2",
+			organizationGUID:    "abc3",
+			spaceGUID:           "abc4",
+			instanceGUID:        "abc5",
+			environment:         "testing",
 			tagManager: &CfTagManager{
 				broker: "AWS Broker",
 				cfNameResolver: &mockCFClientWrapper{
@@ -81,27 +81,27 @@ func TestGenerateTags(t *testing.T) {
 				},
 			},
 			expectedTags: map[string]string{
-				"client":            "Cloud Foundry",
-				"broker":            "AWS Broker",
-				"environment":       "testing",
-				"Service ID":        "abc1",
-				"Plan ID":           "abc2",
-				"Organization GUID": "abc3",
-				"Space GUID":        "abc4",
-				"Instance GUID":     "abc5",
-				"Organization name": "org-1",
-				"Space name":        "space-1",
-				"Instance name":     "instance-1",
+				"client":                "Cloud Foundry",
+				"broker":                "AWS Broker",
+				"environment":           "testing",
+				"Service offering name": "abc1",
+				"Service plan name":     "abc2",
+				"Organization GUID":     "abc3",
+				"Space GUID":            "abc4",
+				"Instance GUID":         "abc5",
+				"Organization name":     "org-1",
+				"Space name":            "space-1",
+				"Instance name":         "instance-1",
 			},
 		},
 		"Update": {
-			action:           Update,
-			serviceID:        "abc1",
-			servicePlanID:    "abc2",
-			organizationGUID: "abc3",
-			spaceGUID:        "abc4",
-			instanceGUID:     "abc5",
-			environment:      "testing",
+			action:              Update,
+			serviceOfferingName: "abc1",
+			servicePlanName:     "abc2",
+			organizationGUID:    "abc3",
+			spaceGUID:           "abc4",
+			instanceGUID:        "abc5",
+			environment:         "testing",
 			tagManager: &CfTagManager{
 				broker: "AWS Broker",
 				cfNameResolver: &mockCFClientWrapper{
@@ -114,17 +114,79 @@ func TestGenerateTags(t *testing.T) {
 				},
 			},
 			expectedTags: map[string]string{
-				"client":            "Cloud Foundry",
-				"broker":            "AWS Broker",
-				"environment":       "testing",
-				"Service ID":        "abc1",
-				"Plan ID":           "abc2",
-				"Organization GUID": "abc3",
-				"Space GUID":        "abc4",
-				"Instance GUID":     "abc5",
-				"Organization name": "org-1",
-				"Space name":        "space-1",
-				"Instance name":     "instance-1",
+				"client":                "Cloud Foundry",
+				"broker":                "AWS Broker",
+				"environment":           "testing",
+				"Service offering name": "abc1",
+				"Service plan name":     "abc2",
+				"Organization GUID":     "abc3",
+				"Space GUID":            "abc4",
+				"Instance GUID":         "abc5",
+				"Organization name":     "org-1",
+				"Space name":            "space-1",
+				"Instance name":         "instance-1",
+			},
+		},
+		"no broker name": {
+			action:              Create,
+			serviceOfferingName: "abc1",
+			servicePlanName:     "abc2",
+			organizationGUID:    "abc3",
+			spaceGUID:           "abc4",
+			instanceGUID:        "abc5",
+			environment:         "",
+			tagManager: &CfTagManager{
+				cfNameResolver: &mockCFClientWrapper{
+					organizationName: "org-1",
+					spaceName:        "space-1",
+					instanceName:     "instance-1",
+					spaceGUID:        "abc4",
+					organizationGUID: "abc3",
+					instanceGUID:     "abc5",
+				},
+			},
+			expectedTags: map[string]string{
+				"client":                "Cloud Foundry",
+				"Service offering name": "abc1",
+				"Service plan name":     "abc2",
+				"Organization GUID":     "abc3",
+				"Space GUID":            "abc4",
+				"Instance GUID":         "abc5",
+				"Organization name":     "org-1",
+				"Space name":            "space-1",
+				"Instance name":         "instance-1",
+			},
+		},
+		"no environment tag": {
+			action:              Create,
+			serviceOfferingName: "abc1",
+			servicePlanName:     "abc2",
+			organizationGUID:    "abc3",
+			spaceGUID:           "abc4",
+			instanceGUID:        "abc5",
+			environment:         "",
+			tagManager: &CfTagManager{
+				broker: "AWS Broker",
+				cfNameResolver: &mockCFClientWrapper{
+					organizationName: "org-1",
+					spaceName:        "space-1",
+					instanceName:     "instance-1",
+					spaceGUID:        "abc4",
+					organizationGUID: "abc3",
+					instanceGUID:     "abc5",
+				},
+			},
+			expectedTags: map[string]string{
+				"client":                "Cloud Foundry",
+				"broker":                "AWS Broker",
+				"Service offering name": "abc1",
+				"Service plan name":     "abc2",
+				"Organization GUID":     "abc3",
+				"Space GUID":            "abc4",
+				"Instance GUID":         "abc5",
+				"Organization name":     "org-1",
+				"Space name":            "space-1",
+				"Instance name":         "instance-1",
 			},
 		},
 	}
@@ -134,8 +196,8 @@ func TestGenerateTags(t *testing.T) {
 			tags, err := test.tagManager.GenerateTags(
 				test.action,
 				test.environment,
-				test.serviceID,
-				test.servicePlanID,
+				test.serviceOfferingName,
+				test.servicePlanName,
 				test.organizationGUID,
 				test.spaceGUID,
 				test.instanceGUID,

--- a/tags_test.go
+++ b/tags_test.go
@@ -8,30 +8,12 @@ import (
 )
 
 type mockCFClientWrapper struct {
-	getServiceOfferingErr error
-	serviceOfferingName   string
-	getServicePlanErr     error
-	servicePlanName       string
-	getOrganizationErr    error
-	organizationName      string
-	getSpaceErr           error
-	spaceName             string
-	getInstanceErr        error
-	instanceName          string
-}
-
-func (m *mockCFClientWrapper) getServiceOfferingName(serviceGUID string) (string, error) {
-	if m.getServiceOfferingErr != nil {
-		return "", m.getServiceOfferingErr
-	}
-	return m.serviceOfferingName, nil
-}
-
-func (m *mockCFClientWrapper) getServicePlanName(servicePlanGUID string) (string, error) {
-	if m.getServicePlanErr != nil {
-		return "", m.getServicePlanErr
-	}
-	return m.servicePlanName, nil
+	getOrganizationErr error
+	organizationName   string
+	getSpaceErr        error
+	spaceName          string
+	getInstanceErr     error
+	instanceName       string
 }
 
 func (m *mockCFClientWrapper) getOrganizationName(organizationGUID string) (string, error) {
@@ -57,77 +39,69 @@ func (m *mockCFClientWrapper) getServiceInstanceName(instanceGUID string) (strin
 
 func TestGenerateTags(t *testing.T) {
 	testCases := map[string]struct {
-		tagManager       *TagManager
+		tagManager       *CfTagManager
 		expectedTags     map[string]string
 		action           Action
-		serviceGUID      string
-		servicePlanGUID  string
+		serviceID        string
+		servicePlanID    string
 		organizationGUID string
 		spaceGUID        string
 		instanceGUID     string
 	}{
 		"Create": {
 			action:           Create,
-			serviceGUID:      "abc1",
-			servicePlanGUID:  "abc2",
+			serviceID:        "abc1",
+			servicePlanID:    "abc2",
 			organizationGUID: "abc3",
 			spaceGUID:        "abc4",
 			instanceGUID:     "abc5",
-			tagManager: &TagManager{
-				broker: "AWS S3 Service Broker",
+			tagManager: &CfTagManager{
+				broker: "AWS Broker",
 				cfNameResolver: &mockCFClientWrapper{
-					serviceOfferingName: "offering-1",
-					servicePlanName:     "plan-1",
-					organizationName:    "org-1",
-					spaceName:           "space-1",
-					instanceName:        "instance-1",
+					organizationName: "org-1",
+					spaceName:        "space-1",
+					instanceName:     "instance-1",
 				},
 			},
 			expectedTags: map[string]string{
-				"client":                "Cloud Foundry",
-				"broker":                "AWS S3 Service Broker",
-				"Service GUID":          "abc1",
-				"Plan GUID":             "abc2",
-				"Organization GUID":     "abc3",
-				"Space GUID":            "abc4",
-				"Instance GUID":         "abc5",
-				"Service offering name": "offering-1",
-				"Service plan name":     "plan-1",
-				"Organization name":     "org-1",
-				"Space name":            "space-1",
-				"Instance name":         "instance-1",
+				"client":            "Cloud Foundry",
+				"broker":            "AWS Broker",
+				"Service ID":        "abc1",
+				"Plan ID":           "abc2",
+				"Organization GUID": "abc3",
+				"Space GUID":        "abc4",
+				"Instance GUID":     "abc5",
+				"Organization name": "org-1",
+				"Space name":        "space-1",
+				"Instance name":     "instance-1",
 			},
 		},
 		"Update": {
 			action:           Update,
-			serviceGUID:      "abc1",
-			servicePlanGUID:  "abc2",
+			serviceID:        "abc1",
+			servicePlanID:    "abc2",
 			organizationGUID: "abc3",
 			spaceGUID:        "abc4",
 			instanceGUID:     "abc5",
-			tagManager: &TagManager{
-				broker: "AWS S3 Service Broker",
+			tagManager: &CfTagManager{
+				broker: "AWS Broker",
 				cfNameResolver: &mockCFClientWrapper{
-					serviceOfferingName: "offering-1",
-					servicePlanName:     "plan-1",
-					organizationName:    "org-1",
-					spaceName:           "space-1",
-					instanceName:        "instance-1",
+					organizationName: "org-1",
+					spaceName:        "space-1",
+					instanceName:     "instance-1",
 				},
 			},
 			expectedTags: map[string]string{
-				"client":                "Cloud Foundry",
-				"broker":                "AWS S3 Service Broker",
-				"Service GUID":          "abc1",
-				"Plan GUID":             "abc2",
-				"Organization GUID":     "abc3",
-				"Space GUID":            "abc4",
-				"Instance GUID":         "abc5",
-				"Service offering name": "offering-1",
-				"Service plan name":     "plan-1",
-				"Organization name":     "org-1",
-				"Space name":            "space-1",
-				"Instance name":         "instance-1",
+				"client":            "Cloud Foundry",
+				"broker":            "AWS Broker",
+				"Service ID":        "abc1",
+				"Plan ID":           "abc2",
+				"Organization GUID": "abc3",
+				"Space GUID":        "abc4",
+				"Instance GUID":     "abc5",
+				"Organization name": "org-1",
+				"Space name":        "space-1",
+				"Instance name":     "instance-1",
 			},
 		},
 	}
@@ -136,8 +110,8 @@ func TestGenerateTags(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			tags, err := test.tagManager.GenerateTags(
 				test.action,
-				test.serviceGUID,
-				test.servicePlanGUID,
+				test.serviceID,
+				test.servicePlanID,
 				test.organizationGUID,
 				test.spaceGUID,
 				test.instanceGUID,
@@ -162,27 +136,11 @@ func TestGenerateTags(t *testing.T) {
 
 func TestGenerateTagsHandleErrors(t *testing.T) {
 	testCases := map[string]struct {
-		tagManager  *TagManager
+		tagManager  *CfTagManager
 		expectedErr error
 	}{
-		"error getting service offering name": {
-			tagManager: &TagManager{
-				cfNameResolver: &mockCFClientWrapper{
-					getServiceOfferingErr: errors.New("error getting service offering name"),
-				},
-			},
-			expectedErr: errors.New("error getting service offering name"),
-		},
-		"error getting service plan name": {
-			tagManager: &TagManager{
-				cfNameResolver: &mockCFClientWrapper{
-					getServicePlanErr: errors.New("error getting service plan name"),
-				},
-			},
-			expectedErr: errors.New("error getting service plan name"),
-		},
 		"error getting organization name": {
-			tagManager: &TagManager{
+			tagManager: &CfTagManager{
 				cfNameResolver: &mockCFClientWrapper{
 					getOrganizationErr: errors.New("error getting organization name"),
 				},
@@ -190,8 +148,8 @@ func TestGenerateTagsHandleErrors(t *testing.T) {
 			expectedErr: errors.New("error getting organization name"),
 		},
 		"error getting space name": {
-			tagManager: &TagManager{
-				broker: "AWS S3 Service Broker",
+			tagManager: &CfTagManager{
+				broker: "AWS Broker",
 				cfNameResolver: &mockCFClientWrapper{
 					getSpaceErr: errors.New("error getting space name"),
 				},
@@ -199,8 +157,8 @@ func TestGenerateTagsHandleErrors(t *testing.T) {
 			expectedErr: errors.New("error getting space name"),
 		},
 		"error getting instance name": {
-			tagManager: &TagManager{
-				broker: "AWS S3 Service Broker",
+			tagManager: &CfTagManager{
+				broker: "AWS Broker",
 				cfNameResolver: &mockCFClientWrapper{
 					getInstanceErr: errors.New("error getting instance name"),
 				},

--- a/tags_test.go
+++ b/tags_test.go
@@ -14,11 +14,17 @@ type mockCFClientWrapper struct {
 	spaceName          string
 	getInstanceErr     error
 	instanceName       string
+	spaceGUID          string
+	organizationGUID   string
+	instanceGUID       string
 }
 
 func (m *mockCFClientWrapper) getOrganizationName(organizationGUID string) (string, error) {
 	if m.getOrganizationErr != nil {
 		return "", m.getOrganizationErr
+	}
+	if m.organizationGUID != "" && m.organizationGUID != organizationGUID {
+		return "", errors.New("organization GUID does not match expected value")
 	}
 	return m.organizationName, nil
 }
@@ -27,12 +33,18 @@ func (m *mockCFClientWrapper) getSpaceName(spaceGUID string) (string, error) {
 	if m.getSpaceErr != nil {
 		return "", m.getSpaceErr
 	}
+	if m.spaceGUID != "" && m.spaceGUID != spaceGUID {
+		return "", errors.New("space GUID does not match expected value")
+	}
 	return m.spaceName, nil
 }
 
 func (m *mockCFClientWrapper) getServiceInstanceName(instanceGUID string) (string, error) {
 	if m.getInstanceErr != nil {
 		return "", m.getInstanceErr
+	}
+	if m.instanceGUID != "" && m.instanceGUID != instanceGUID {
+		return "", errors.New("instance GUID does not match expected value")
 	}
 	return m.instanceName, nil
 }
@@ -61,6 +73,9 @@ func TestGenerateTags(t *testing.T) {
 					organizationName: "org-1",
 					spaceName:        "space-1",
 					instanceName:     "instance-1",
+					spaceGUID:        "abc4",
+					organizationGUID: "abc3",
+					instanceGUID:     "abc5",
 				},
 			},
 			expectedTags: map[string]string{
@@ -89,6 +104,9 @@ func TestGenerateTags(t *testing.T) {
 					organizationName: "org-1",
 					spaceName:        "space-1",
 					instanceName:     "instance-1",
+					spaceGUID:        "abc4",
+					organizationGUID: "abc3",
+					instanceGUID:     "abc5",
 				},
 			},
 			expectedTags: map[string]string{

--- a/tags_test.go
+++ b/tags_test.go
@@ -54,6 +54,7 @@ func TestGenerateTags(t *testing.T) {
 		tagManager       *CfTagManager
 		expectedTags     map[string]string
 		action           Action
+		environment      string
 		serviceID        string
 		servicePlanID    string
 		organizationGUID string
@@ -67,6 +68,7 @@ func TestGenerateTags(t *testing.T) {
 			organizationGUID: "abc3",
 			spaceGUID:        "abc4",
 			instanceGUID:     "abc5",
+			environment:      "testing",
 			tagManager: &CfTagManager{
 				broker: "AWS Broker",
 				cfNameResolver: &mockCFClientWrapper{
@@ -81,6 +83,7 @@ func TestGenerateTags(t *testing.T) {
 			expectedTags: map[string]string{
 				"client":            "Cloud Foundry",
 				"broker":            "AWS Broker",
+				"environment":       "testing",
 				"Service ID":        "abc1",
 				"Plan ID":           "abc2",
 				"Organization GUID": "abc3",
@@ -98,6 +101,7 @@ func TestGenerateTags(t *testing.T) {
 			organizationGUID: "abc3",
 			spaceGUID:        "abc4",
 			instanceGUID:     "abc5",
+			environment:      "testing",
 			tagManager: &CfTagManager{
 				broker: "AWS Broker",
 				cfNameResolver: &mockCFClientWrapper{
@@ -112,6 +116,7 @@ func TestGenerateTags(t *testing.T) {
 			expectedTags: map[string]string{
 				"client":            "Cloud Foundry",
 				"broker":            "AWS Broker",
+				"environment":       "testing",
 				"Service ID":        "abc1",
 				"Plan ID":           "abc2",
 				"Organization GUID": "abc3",
@@ -128,6 +133,7 @@ func TestGenerateTags(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			tags, err := test.tagManager.GenerateTags(
 				test.action,
+				test.environment,
 				test.serviceID,
 				test.servicePlanID,
 				test.organizationGUID,
@@ -189,6 +195,7 @@ func TestGenerateTagsHandleErrors(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			_, err := test.tagManager.GenerateTags(
 				Create,
+				"testing",
 				"abc1",
 				"abc2",
 				"abc3",


### PR DESCRIPTION
## Changes proposed in this pull request:

- Refactor code to accept required settings for CF client as arguments instead of getting them from environment variables. This puts the calling code in control of how to get the required values, whether from environment variables or some other storage
- Remove code setting instance name tag. There is a race condition when trying to get the name of a new instance to tag the AWS resource but the instance has not finished creating it yet. There's not much value in cost aggregation on instance names, so it was easiest to just remove this tag
  - Removed code/tests related to getting/setting instance name tags
- Removed code for getting/setting service offering name and service plan name tags. It turns out these values can be passed in directly from the calling broker. Moreover, there is no GUID available for service offering or service plan in a provision request with which to look up the CF resources: https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#provisioning. For example, the service offering ID, which is internal to the broker's tracking of its offerings, **is not the same as the service offering GUID**.
- Add an `environment` tag (e.g. "development") and update tests

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

No real security considerations, just updating the tags generated by this module 
