### PR TITLE
Refactor environment tag

### DIFF
--- a/cf.go
+++ b/cf.go
@@ -9,8 +9,8 @@ import (
 )
 
 type NameResolver interface {
-	getOrganizationName(organizationGUID string) (string, error)
-	getSpaceName(spaceGUID string) (string, error)
+	getOrganization(organizationGUID string) (*resource.Organization, error)
+	getSpace(spaceGUID string) (*resource.Space, error)
 	getServiceInstance(instanceGUID string) (*resource.ServiceInstance, error)
 }
 
@@ -56,20 +56,20 @@ func newCFNameResolver(
 	}, nil
 }
 
-func (c *cfNameResolver) getOrganizationName(organizationGUID string) (string, error) {
+func (c *cfNameResolver) getOrganization(organizationGUID string) (*resource.Organization, error) {
 	organization, err := c.Organizations.Get(context.Background(), organizationGUID)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return organization.Name, nil
+	return organization, nil
 }
 
-func (c *cfNameResolver) getSpaceName(spaceGUID string) (string, error) {
+func (c *cfNameResolver) getSpace(spaceGUID string) (*resource.Space, error) {
 	space, err := c.Spaces.Get(context.Background(), spaceGUID)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return space.Name, nil
+	return space, nil
 }
 
 func (c *cfNameResolver) getServiceInstance(instanceGUID string) (*resource.ServiceInstance, error) {

--- a/cf.go
+++ b/cf.go
@@ -11,6 +11,7 @@ import (
 type NameResolver interface {
 	getOrganizationName(organizationGUID string) (string, error)
 	getSpaceName(spaceGUID string) (string, error)
+	getServiceInstance(instanceGUID string) (*resource.ServiceInstance, error)
 }
 
 type OrganizationGetter interface {
@@ -21,9 +22,14 @@ type SpaceGetter interface {
 	Get(ctx context.Context, guid string) (*resource.Space, error)
 }
 
+type ServiceInstanceGetter interface {
+	Get(ctx context.Context, guid string) (*resource.ServiceInstance, error)
+}
+
 type cfNameResolver struct {
-	Organizations OrganizationGetter
-	Spaces        SpaceGetter
+	Organizations    OrganizationGetter
+	Spaces           SpaceGetter
+	ServiceInstances ServiceInstanceGetter
 }
 
 func newCFNameResolver(
@@ -44,8 +50,9 @@ func newCFNameResolver(
 		return nil, err
 	}
 	return &cfNameResolver{
-		Organizations: cf.Organizations,
-		Spaces:        cf.Spaces,
+		Organizations:    cf.Organizations,
+		Spaces:           cf.Spaces,
+		ServiceInstances: cf.ServiceInstances,
 	}, nil
 }
 
@@ -63,4 +70,12 @@ func (c *cfNameResolver) getSpaceName(spaceGUID string) (string, error) {
 		return "", err
 	}
 	return space.Name, nil
+}
+
+func (c *cfNameResolver) getServiceInstance(instanceGUID string) (*resource.ServiceInstance, error) {
+	instance, err := c.ServiceInstances.Get(context.Background(), instanceGUID)
+	if err != nil {
+		return nil, err
+	}
+	return instance, nil
 }

--- a/cf.go
+++ b/cf.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cloudfoundry-community/go-cfclient/v3/resource"
 )
 
-type NameResolver interface {
+type ResourceGetter interface {
 	getOrganization(organizationGUID string) (*resource.Organization, error)
 	getSpace(spaceGUID string) (*resource.Space, error)
 	getServiceInstance(instanceGUID string) (*resource.ServiceInstance, error)
@@ -26,17 +26,17 @@ type ServiceInstanceGetter interface {
 	Get(ctx context.Context, guid string) (*resource.ServiceInstance, error)
 }
 
-type cfNameResolver struct {
+type cfResourceGetter struct {
 	Organizations    OrganizationGetter
 	Spaces           SpaceGetter
 	ServiceInstances ServiceInstanceGetter
 }
 
-func newCFNameResolver(
+func newCFResourceGetter(
 	cfApiUrl string,
 	cfApiClientId string,
 	cfApiClientSecret string,
-) (*cfNameResolver, error) {
+) (*cfResourceGetter, error) {
 	cfg, err := config.NewClientSecret(
 		cfApiUrl,
 		cfApiClientId,
@@ -49,14 +49,14 @@ func newCFNameResolver(
 	if err != nil {
 		return nil, err
 	}
-	return &cfNameResolver{
+	return &cfResourceGetter{
 		Organizations:    cf.Organizations,
 		Spaces:           cf.Spaces,
 		ServiceInstances: cf.ServiceInstances,
 	}, nil
 }
 
-func (c *cfNameResolver) getOrganization(organizationGUID string) (*resource.Organization, error) {
+func (c *cfResourceGetter) getOrganization(organizationGUID string) (*resource.Organization, error) {
 	organization, err := c.Organizations.Get(context.Background(), organizationGUID)
 	if err != nil {
 		return nil, err
@@ -64,7 +64,7 @@ func (c *cfNameResolver) getOrganization(organizationGUID string) (*resource.Org
 	return organization, nil
 }
 
-func (c *cfNameResolver) getSpace(spaceGUID string) (*resource.Space, error) {
+func (c *cfResourceGetter) getSpace(spaceGUID string) (*resource.Space, error) {
 	space, err := c.Spaces.Get(context.Background(), spaceGUID)
 	if err != nil {
 		return nil, err
@@ -72,7 +72,7 @@ func (c *cfNameResolver) getSpace(spaceGUID string) (*resource.Space, error) {
 	return space, nil
 }
 
-func (c *cfNameResolver) getServiceInstance(instanceGUID string) (*resource.ServiceInstance, error) {
+func (c *cfResourceGetter) getServiceInstance(instanceGUID string) (*resource.ServiceInstance, error) {
 	instance, err := c.ServiceInstances.Get(context.Background(), instanceGUID)
 	if err != nil {
 		return nil, err

--- a/cf_test.go
+++ b/cf_test.go
@@ -48,13 +48,13 @@ func (s *mockSpaces) Get(ctx context.Context, guid string) (*resource.Space, err
 
 func TestGetOrganization(t *testing.T) {
 	testCases := map[string]struct {
-		cfClientWrapper      *cfResourceGetter
+		cfResourceGetter     *cfResourceGetter
 		expectedOrganization *resource.Organization
 		expectedErr          error
 		organizationGuid     string
 	}{
 		"success": {
-			cfClientWrapper: &cfResourceGetter{
+			cfResourceGetter: &cfResourceGetter{
 				Organizations: &mockOrganizations{
 					organizationName: "org-1",
 					organizationGuid: "guid-1",
@@ -67,7 +67,7 @@ func TestGetOrganization(t *testing.T) {
 			},
 		},
 		"error": {
-			cfClientWrapper: &cfResourceGetter{
+			cfResourceGetter: &cfResourceGetter{
 				Organizations: &mockOrganizations{
 					getOrganizationErr: errors.New("error getting organization"),
 				},
@@ -79,7 +79,7 @@ func TestGetOrganization(t *testing.T) {
 
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
-			organization, err := test.cfClientWrapper.getOrganization(test.organizationGuid)
+			organization, err := test.cfResourceGetter.getOrganization(test.organizationGuid)
 			if !cmp.Equal(organization, test.expectedOrganization) {
 				t.Errorf(cmp.Diff(organization, test.expectedOrganization))
 			}
@@ -93,13 +93,13 @@ func TestGetOrganization(t *testing.T) {
 
 func TestGetSpace(t *testing.T) {
 	testCases := map[string]struct {
-		cfClientWrapper *cfResourceGetter
-		expectedSpace   *resource.Space
-		expectedErr     error
-		spaceGuid       string
+		cfResourceGetter *cfResourceGetter
+		expectedSpace    *resource.Space
+		expectedErr      error
+		spaceGuid        string
 	}{
 		"success": {
-			cfClientWrapper: &cfResourceGetter{
+			cfResourceGetter: &cfResourceGetter{
 				Organizations: &mockOrganizations{},
 				Spaces: &mockSpaces{
 					spaceName: "space-1",
@@ -112,7 +112,7 @@ func TestGetSpace(t *testing.T) {
 			},
 		},
 		"error": {
-			cfClientWrapper: &cfResourceGetter{
+			cfResourceGetter: &cfResourceGetter{
 				Organizations: &mockOrganizations{},
 				Spaces: &mockSpaces{
 					getSpaceErr: errors.New("error getting space"),
@@ -124,7 +124,7 @@ func TestGetSpace(t *testing.T) {
 
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
-			space, err := test.cfClientWrapper.getSpace(test.spaceGuid)
+			space, err := test.cfResourceGetter.getSpace(test.spaceGuid)
 			if !cmp.Equal(space, test.expectedSpace) {
 				t.Errorf(cmp.Diff(space, test.expectedSpace))
 			}

--- a/cf_test.go
+++ b/cf_test.go
@@ -48,13 +48,13 @@ func (s *mockSpaces) Get(ctx context.Context, guid string) (*resource.Space, err
 
 func TestGetOrganization(t *testing.T) {
 	testCases := map[string]struct {
-		cfClientWrapper      *cfNameResolver
+		cfClientWrapper      *cfResourceGetter
 		expectedOrganization *resource.Organization
 		expectedErr          error
 		organizationGuid     string
 	}{
 		"success": {
-			cfClientWrapper: &cfNameResolver{
+			cfClientWrapper: &cfResourceGetter{
 				Organizations: &mockOrganizations{
 					organizationName: "org-1",
 					organizationGuid: "guid-1",
@@ -67,7 +67,7 @@ func TestGetOrganization(t *testing.T) {
 			},
 		},
 		"error": {
-			cfClientWrapper: &cfNameResolver{
+			cfClientWrapper: &cfResourceGetter{
 				Organizations: &mockOrganizations{
 					getOrganizationErr: errors.New("error getting organization"),
 				},
@@ -93,13 +93,13 @@ func TestGetOrganization(t *testing.T) {
 
 func TestGetSpace(t *testing.T) {
 	testCases := map[string]struct {
-		cfClientWrapper *cfNameResolver
+		cfClientWrapper *cfResourceGetter
 		expectedSpace   *resource.Space
 		expectedErr     error
 		spaceGuid       string
 	}{
 		"success": {
-			cfClientWrapper: &cfNameResolver{
+			cfClientWrapper: &cfResourceGetter{
 				Organizations: &mockOrganizations{},
 				Spaces: &mockSpaces{
 					spaceName: "space-1",
@@ -112,7 +112,7 @@ func TestGetSpace(t *testing.T) {
 			},
 		},
 		"error": {
-			cfClientWrapper: &cfNameResolver{
+			cfClientWrapper: &cfResourceGetter{
 				Organizations: &mockOrganizations{},
 				Spaces: &mockSpaces{
 					getSpaceErr: errors.New("error getting space"),

--- a/tags.go
+++ b/tags.go
@@ -61,9 +61,9 @@ func (t *CfTagManager) GenerateTags(
 	action Action,
 	serviceName string,
 	planName string,
-	organizationGUID string,
-	spaceGUID string,
 	instanceGUID string,
+	spaceGUID string,
+	organizationGUID string,
 ) (map[string]string, error) {
 	tags := make(map[string]string)
 
@@ -87,14 +87,16 @@ func (t *CfTagManager) GenerateTags(
 		tags[ServicePlanName] = planName
 	}
 
-	if organizationGUID != "" {
-		tags[OrganizationGUIDTagKey] = organizationGUID
+	if instanceGUID != "" {
+		tags[ServiceInstanceGUIDTagKey] = instanceGUID
+	}
 
-		organizationName, err := t.cfNameResolver.getOrganizationName(organizationGUID)
+	if instanceGUID != "" && spaceGUID == "" {
+		instance, err := t.cfNameResolver.getServiceInstance(instanceGUID)
 		if err != nil {
 			return nil, err
 		}
-		tags[OrganizationNameTagKey] = organizationName
+		spaceGUID = instance.Relationships.Space.Data.GUID
 	}
 
 	if spaceGUID != "" {
@@ -107,8 +109,14 @@ func (t *CfTagManager) GenerateTags(
 		tags[SpaceNameTagKey] = spaceName
 	}
 
-	if instanceGUID != "" {
-		tags[ServiceInstanceGUIDTagKey] = instanceGUID
+	if organizationGUID != "" {
+		tags[OrganizationGUIDTagKey] = organizationGUID
+
+		organizationName, err := t.cfNameResolver.getOrganizationName(organizationGUID)
+		if err != nil {
+			return nil, err
+		}
+		tags[OrganizationNameTagKey] = organizationName
 	}
 
 	return tags, nil

--- a/tags.go
+++ b/tags.go
@@ -59,9 +59,9 @@ func NewCFTagManager(
 }
 
 type ResourceGUIDs struct {
-	instanceGUID     string
-	spaceGUID        string
-	organizationGUID string
+	InstanceGUID     string
+	SpaceGUID        string
+	OrganizationGUID string
 }
 
 func (t *CfTagManager) GenerateTags(
@@ -93,8 +93,8 @@ func (t *CfTagManager) GenerateTags(
 		tags[ServicePlanName] = planName
 	}
 
-	if resourceGUIDs.instanceGUID != "" {
-		tags[ServiceInstanceGUIDTagKey] = resourceGUIDs.instanceGUID
+	if resourceGUIDs.InstanceGUID != "" {
+		tags[ServiceInstanceGUIDTagKey] = resourceGUIDs.InstanceGUID
 	}
 
 	var (
@@ -105,9 +105,9 @@ func (t *CfTagManager) GenerateTags(
 		err              error
 	)
 
-	spaceGUID = resourceGUIDs.spaceGUID
+	spaceGUID = resourceGUIDs.SpaceGUID
 	if spaceGUID == "" && getMissingResources {
-		spaceGUID, err = t.getSpaceGuid(resourceGUIDs.instanceGUID)
+		spaceGUID, err = t.getSpaceGuid(resourceGUIDs.InstanceGUID)
 		if err != nil {
 			return nil, err
 		}
@@ -128,7 +128,7 @@ func (t *CfTagManager) GenerateTags(
 		tags[SpaceNameTagKey] = space.Name
 	}
 
-	organizationGUID = resourceGUIDs.organizationGUID
+	organizationGUID = resourceGUIDs.OrganizationGUID
 	if organizationGUID == "" && getMissingResources {
 		organizationGUID = t.getOrganizationGuidFromSpace(space)
 	}

--- a/tags.go
+++ b/tags.go
@@ -30,9 +30,9 @@ type TagManager interface {
 }
 
 type CfTagManager struct {
-	broker         string
-	environment    string
-	cfNameResolver NameResolver
+	broker           string
+	environment      string
+	cfResourceGetter ResourceGetter
 }
 
 func NewCFTagManager(
@@ -42,7 +42,7 @@ func NewCFTagManager(
 	cfApiClientId string,
 	cfApiClientSecret string,
 ) (*CfTagManager, error) {
-	cfNameResolver, err := newCFNameResolver(
+	cfResourceGetter, err := newCFResourceGetter(
 		cfApiUrl,
 		cfApiClientId,
 		cfApiClientSecret,
@@ -53,7 +53,7 @@ func NewCFTagManager(
 	return &CfTagManager{
 		broker,
 		environment,
-		cfNameResolver,
+		cfResourceGetter,
 	}, nil
 }
 
@@ -99,7 +99,7 @@ func (t *CfTagManager) GenerateTags(
 	if spaceGUID != "" {
 		tags[SpaceGUIDTagKey] = spaceGUID
 
-		space, err := t.cfNameResolver.getSpace(spaceGUID)
+		space, err := t.cfResourceGetter.getSpace(spaceGUID)
 		if err != nil {
 			return nil, err
 		}
@@ -114,7 +114,7 @@ func (t *CfTagManager) GenerateTags(
 	if organizationGUID != "" {
 		tags[OrganizationGUIDTagKey] = organizationGUID
 
-		organization, err := t.cfNameResolver.getOrganization(organizationGUID)
+		organization, err := t.cfResourceGetter.getOrganization(organizationGUID)
 		if err != nil {
 			return nil, err
 		}
@@ -132,7 +132,7 @@ func (t *CfTagManager) getSpaceGuid(
 		return spaceGUID, nil
 	}
 	if instanceGUID != "" {
-		instance, err := t.cfNameResolver.getServiceInstance(instanceGUID)
+		instance, err := t.cfResourceGetter.getServiceInstance(instanceGUID)
 		if err != nil {
 			return spaceGUID, err
 		}
@@ -149,7 +149,7 @@ func (t *CfTagManager) getOrganizationGuid(
 		return organizationGUID, nil
 	}
 	if spaceGUID != "" {
-		space, err := t.cfNameResolver.getSpace(spaceGUID)
+		space, err := t.cfResourceGetter.getSpace(spaceGUID)
 		if err != nil {
 			return organizationGUID, err
 		}

--- a/tags.go
+++ b/tags.go
@@ -21,7 +21,6 @@ const (
 type TagManager interface {
 	GenerateTags(
 		action Action,
-		environment string,
 		serviceName string,
 		servicePlanName string,
 		organizationGUID string,
@@ -32,11 +31,13 @@ type TagManager interface {
 
 type CfTagManager struct {
 	broker         string
+	environment    string
 	cfNameResolver NameResolver
 }
 
 func NewCFTagManager(
 	broker string,
+	environment string,
 	cfApiUrl string,
 	cfApiClientId string,
 	cfApiClientSecret string,
@@ -51,13 +52,13 @@ func NewCFTagManager(
 	}
 	return &CfTagManager{
 		broker,
+		environment,
 		cfNameResolver,
 	}, nil
 }
 
 func (t *CfTagManager) GenerateTags(
 	action Action,
-	environment string,
 	serviceName string,
 	planName string,
 	organizationGUID string,
@@ -74,8 +75,8 @@ func (t *CfTagManager) GenerateTags(
 		tags[BrokerTagKey] = t.broker
 	}
 
-	if environment != "" {
-		tags[EnvironmentTagKey] = strings.ToLower(environment)
+	if t.environment != "" {
+		tags[EnvironmentTagKey] = strings.ToLower(t.environment)
 	}
 
 	if serviceName != "" {

--- a/tags.go
+++ b/tags.go
@@ -25,9 +25,8 @@ type TagManager interface {
 		action Action,
 		serviceName string,
 		servicePlanName string,
-		organizationGUID string,
-		spaceGUID string,
-		instanceGUID string,
+		resourceGUIDs ResourceGUIDs,
+		getMissingResources bool,
 	) (map[string]string, error)
 }
 

--- a/tags_test.go
+++ b/tags_test.go
@@ -351,6 +351,7 @@ func TestGetSpaceGuid(t *testing.T) {
 		tagManager   *CfTagManager
 		instanceGUID string
 		expectedGuid string
+		expectedErr  error
 	}{
 		"success": {
 			tagManager: &CfTagManager{
@@ -362,13 +363,25 @@ func TestGetSpaceGuid(t *testing.T) {
 			instanceGUID: "instance-1",
 			expectedGuid: "space-1",
 		},
+		"error": {
+			tagManager: &CfTagManager{
+				cfResourceGetter: &mockCFClientWrapper{
+					getServiceInstanceErr: errors.New("error getting service instance"),
+				},
+			},
+			expectedErr: errors.New("error getting service instance"),
+		},
 	}
 
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
-			spaceGUID, _ := test.tagManager.getSpaceGuid(test.instanceGUID)
+			spaceGUID, err := test.tagManager.getSpaceGuid(test.instanceGUID)
 			if spaceGUID != test.expectedGuid {
-				t.Fatal("fail")
+				t.Errorf("expected: %s, got: %s", test.expectedGuid, spaceGUID)
+			}
+			if (test.expectedErr != nil && err == nil) ||
+				(err != nil && err.Error() != test.expectedErr.Error()) {
+				t.Errorf("expected error: %s, got: %s", test.expectedErr, err)
 			}
 		})
 	}
@@ -379,6 +392,7 @@ func TestGetOrganizationGuid(t *testing.T) {
 		tagManager   *CfTagManager
 		spaceGUID    string
 		expectedGuid string
+		expectedErr  error
 	}{
 		"success": {
 			tagManager: &CfTagManager{
@@ -390,13 +404,25 @@ func TestGetOrganizationGuid(t *testing.T) {
 			spaceGUID:    "space-1",
 			expectedGuid: "org-1",
 		},
+		"error": {
+			tagManager: &CfTagManager{
+				cfResourceGetter: &mockCFClientWrapper{
+					getSpaceErr: errors.New("error getting space"),
+				},
+			},
+			expectedErr: errors.New("error getting space"),
+		},
 	}
 
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
-			spaceGUID, _ := test.tagManager.getOrganizationGuid(test.spaceGUID)
-			if spaceGUID != test.expectedGuid {
-				t.Fatal("fail")
+			organizationGUID, err := test.tagManager.getOrganizationGuid(test.spaceGUID)
+			if organizationGUID != test.expectedGuid {
+				t.Errorf("expected: %s, got: %s", test.expectedGuid, organizationGUID)
+			}
+			if (test.expectedErr != nil && err == nil) ||
+				(err != nil && err.Error() != test.expectedErr.Error()) {
+				t.Errorf("expected error: %s, got: %s", test.expectedErr, err)
 			}
 		})
 	}

--- a/tags_test.go
+++ b/tags_test.go
@@ -345,3 +345,59 @@ func TestGenerateTagsHandleErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestGetSpaceGuid(t *testing.T) {
+	testCases := map[string]struct {
+		tagManager   *CfTagManager
+		instanceGUID string
+		expectedGuid string
+	}{
+		"success": {
+			tagManager: &CfTagManager{
+				cfResourceGetter: &mockCFClientWrapper{
+					instanceGUID: "instance-1",
+					spaceGUID:    "space-1",
+				},
+			},
+			instanceGUID: "instance-1",
+			expectedGuid: "space-1",
+		},
+	}
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			spaceGUID, _ := test.tagManager.getSpaceGuid(test.instanceGUID)
+			if spaceGUID != test.expectedGuid {
+				t.Fatal("fail")
+			}
+		})
+	}
+}
+
+func TestGetOrganizationGuid(t *testing.T) {
+	testCases := map[string]struct {
+		tagManager   *CfTagManager
+		spaceGUID    string
+		expectedGuid string
+	}{
+		"success": {
+			tagManager: &CfTagManager{
+				cfResourceGetter: &mockCFClientWrapper{
+					organizationGUID: "org-1",
+					spaceGUID:        "space-1",
+				},
+			},
+			spaceGUID:    "space-1",
+			expectedGuid: "org-1",
+		},
+	}
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			spaceGUID, _ := test.tagManager.getOrganizationGuid(test.spaceGUID)
+			if spaceGUID != test.expectedGuid {
+				t.Fatal("fail")
+			}
+		})
+	}
+}

--- a/tags_test.go
+++ b/tags_test.go
@@ -42,7 +42,6 @@ func TestGenerateTags(t *testing.T) {
 		tagManager          *CfTagManager
 		expectedTags        map[string]string
 		action              Action
-		environment         string
 		serviceOfferingName string
 		servicePlanName     string
 		organizationGUID    string
@@ -56,9 +55,9 @@ func TestGenerateTags(t *testing.T) {
 			organizationGUID:    "abc3",
 			spaceGUID:           "abc4",
 			instanceGUID:        "abc5",
-			environment:         "testing",
 			tagManager: &CfTagManager{
-				broker: "AWS Broker",
+				broker:      "AWS Broker",
+				environment: "testing",
 				cfNameResolver: &mockCFClientWrapper{
 					organizationName: "org-1",
 					spaceName:        "space-1",
@@ -87,9 +86,9 @@ func TestGenerateTags(t *testing.T) {
 			organizationGUID:    "abc3",
 			spaceGUID:           "abc4",
 			instanceGUID:        "abc5",
-			environment:         "testing",
 			tagManager: &CfTagManager{
-				broker: "AWS Broker",
+				broker:      "AWS Broker",
+				environment: "testing",
 				cfNameResolver: &mockCFClientWrapper{
 					organizationName: "org-1",
 					spaceName:        "space-1",
@@ -118,8 +117,8 @@ func TestGenerateTags(t *testing.T) {
 			organizationGUID:    "abc3",
 			spaceGUID:           "abc4",
 			instanceGUID:        "abc5",
-			environment:         "",
 			tagManager: &CfTagManager{
+				environment: "testing",
 				cfNameResolver: &mockCFClientWrapper{
 					organizationName: "org-1",
 					spaceName:        "space-1",
@@ -130,6 +129,7 @@ func TestGenerateTags(t *testing.T) {
 			},
 			expectedTags: map[string]string{
 				"client":                "Cloud Foundry",
+				"environment":           "testing",
 				"Service offering name": "abc1",
 				"Service plan name":     "abc2",
 				"Organization GUID":     "abc3",
@@ -146,7 +146,6 @@ func TestGenerateTags(t *testing.T) {
 			organizationGUID:    "abc3",
 			spaceGUID:           "abc4",
 			instanceGUID:        "abc5",
-			environment:         "",
 			tagManager: &CfTagManager{
 				broker: "AWS Broker",
 				cfNameResolver: &mockCFClientWrapper{
@@ -175,7 +174,6 @@ func TestGenerateTags(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			tags, err := test.tagManager.GenerateTags(
 				test.action,
-				test.environment,
 				test.serviceOfferingName,
 				test.servicePlanName,
 				test.organizationGUID,
@@ -228,7 +226,6 @@ func TestGenerateTagsHandleErrors(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			_, err := test.tagManager.GenerateTags(
 				Create,
-				"testing",
 				"abc1",
 				"abc2",
 				"abc3",

--- a/tags_test.go
+++ b/tags_test.go
@@ -91,9 +91,9 @@ func TestGenerateTags(t *testing.T) {
 			serviceOfferingName: "abc1",
 			servicePlanName:     "abc2",
 			resourceGUIDS: ResourceGUIDs{
-				organizationGUID: "abc3",
-				spaceGUID:        "abc4",
-				instanceGUID:     "abc5",
+				OrganizationGUID: "abc3",
+				SpaceGUID:        "abc4",
+				InstanceGUID:     "abc5",
 			},
 			tagManager: &CfTagManager{
 				broker:      "AWS Broker",
@@ -125,9 +125,9 @@ func TestGenerateTags(t *testing.T) {
 			serviceOfferingName: "abc1",
 			servicePlanName:     "abc2",
 			resourceGUIDS: ResourceGUIDs{
-				organizationGUID: "abc3",
-				spaceGUID:        "abc4",
-				instanceGUID:     "abc5",
+				OrganizationGUID: "abc3",
+				SpaceGUID:        "abc4",
+				InstanceGUID:     "abc5",
 			},
 			tagManager: &CfTagManager{
 				broker:      "AWS Broker",
@@ -159,9 +159,9 @@ func TestGenerateTags(t *testing.T) {
 			serviceOfferingName: "abc1",
 			servicePlanName:     "abc2",
 			resourceGUIDS: ResourceGUIDs{
-				organizationGUID: "abc3",
-				spaceGUID:        "abc4",
-				instanceGUID:     "abc5",
+				OrganizationGUID: "abc3",
+				SpaceGUID:        "abc4",
+				InstanceGUID:     "abc5",
 			},
 			tagManager: &CfTagManager{
 				environment: "testing",
@@ -191,9 +191,9 @@ func TestGenerateTags(t *testing.T) {
 			serviceOfferingName: "abc1",
 			servicePlanName:     "abc2",
 			resourceGUIDS: ResourceGUIDs{
-				organizationGUID: "abc3",
-				spaceGUID:        "abc4",
-				instanceGUID:     "abc5",
+				OrganizationGUID: "abc3",
+				SpaceGUID:        "abc4",
+				InstanceGUID:     "abc5",
 			},
 			tagManager: &CfTagManager{
 				broker: "AWS Broker",
@@ -223,8 +223,8 @@ func TestGenerateTags(t *testing.T) {
 			serviceOfferingName: "abc1",
 			servicePlanName:     "abc2",
 			resourceGUIDS: ResourceGUIDs{
-				spaceGUID:    "abc4",
-				instanceGUID: "abc5",
+				SpaceGUID:    "abc4",
+				InstanceGUID: "abc5",
 			},
 			getMissingResources: true,
 			tagManager: &CfTagManager{
@@ -257,7 +257,7 @@ func TestGenerateTags(t *testing.T) {
 			serviceOfferingName: "abc1",
 			servicePlanName:     "abc2",
 			resourceGUIDS: ResourceGUIDs{
-				instanceGUID: "abc5",
+				InstanceGUID: "abc5",
 			},
 			getMissingResources: true,
 			tagManager: &CfTagManager{
@@ -291,8 +291,8 @@ func TestGenerateTags(t *testing.T) {
 			serviceOfferingName: "abc1",
 			servicePlanName:     "abc2",
 			resourceGUIDS: ResourceGUIDs{
-				spaceGUID:    "abc4",
-				instanceGUID: "abc5",
+				SpaceGUID:    "abc4",
+				InstanceGUID: "abc5",
 			},
 			tagManager: &CfTagManager{
 				broker:      "AWS Broker",
@@ -321,7 +321,7 @@ func TestGenerateTags(t *testing.T) {
 			serviceOfferingName: "abc1",
 			servicePlanName:     "abc2",
 			resourceGUIDS: ResourceGUIDs{
-				instanceGUID: "abc5",
+				InstanceGUID: "abc5",
 			},
 			tagManager: &CfTagManager{
 				broker:      "AWS Broker",
@@ -411,9 +411,9 @@ func TestGenerateTagsHandleErrors(t *testing.T) {
 				"abc1",
 				"abc2",
 				ResourceGUIDs{
-					organizationGUID: "org-1",
-					instanceGUID:     "instance-1",
-					spaceGUID:        "space-1",
+					OrganizationGUID: "org-1",
+					InstanceGUID:     "instance-1",
+					SpaceGUID:        "space-1",
 				},
 				false,
 			)

--- a/tags_test.go
+++ b/tags_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/cloudfoundry-community/go-cfclient/v3/resource"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -35,6 +36,10 @@ func (m *mockCFClientWrapper) getSpaceName(spaceGUID string) (string, error) {
 		return "", errors.New("space GUID does not match expected value")
 	}
 	return m.spaceName, nil
+}
+
+func (m *mockCFClientWrapper) getServiceInstance(instanceGUID string) (*resource.ServiceInstance, error) {
+	return nil, nil
 }
 
 func TestGenerateTags(t *testing.T) {

--- a/tags_test.go
+++ b/tags_test.go
@@ -67,7 +67,7 @@ func TestGenerateTags(t *testing.T) {
 			tagManager: &CfTagManager{
 				broker:      "AWS Broker",
 				environment: "testing",
-				cfNameResolver: &mockCFClientWrapper{
+				cfResourceGetter: &mockCFClientWrapper{
 					organizationName: "org-1",
 					spaceName:        "space-1",
 					spaceGUID:        "abc4",
@@ -98,7 +98,7 @@ func TestGenerateTags(t *testing.T) {
 			tagManager: &CfTagManager{
 				broker:      "AWS Broker",
 				environment: "testing",
-				cfNameResolver: &mockCFClientWrapper{
+				cfResourceGetter: &mockCFClientWrapper{
 					organizationName: "org-1",
 					spaceName:        "space-1",
 					spaceGUID:        "abc4",
@@ -128,7 +128,7 @@ func TestGenerateTags(t *testing.T) {
 			instanceGUID:        "abc5",
 			tagManager: &CfTagManager{
 				environment: "testing",
-				cfNameResolver: &mockCFClientWrapper{
+				cfResourceGetter: &mockCFClientWrapper{
 					organizationName: "org-1",
 					spaceName:        "space-1",
 					spaceGUID:        "abc4",
@@ -157,7 +157,7 @@ func TestGenerateTags(t *testing.T) {
 			instanceGUID:        "abc5",
 			tagManager: &CfTagManager{
 				broker: "AWS Broker",
-				cfNameResolver: &mockCFClientWrapper{
+				cfResourceGetter: &mockCFClientWrapper{
 					organizationName: "org-1",
 					spaceName:        "space-1",
 					spaceGUID:        "abc4",
@@ -214,7 +214,7 @@ func TestGenerateTagsHandleErrors(t *testing.T) {
 	}{
 		"error getting organization": {
 			tagManager: &CfTagManager{
-				cfNameResolver: &mockCFClientWrapper{
+				cfResourceGetter: &mockCFClientWrapper{
 					getOrganizationErr: errors.New("error getting organization"),
 				},
 			},
@@ -223,7 +223,7 @@ func TestGenerateTagsHandleErrors(t *testing.T) {
 		"error getting space": {
 			tagManager: &CfTagManager{
 				broker: "AWS Broker",
-				cfNameResolver: &mockCFClientWrapper{
+				cfResourceGetter: &mockCFClientWrapper{
 					getSpaceErr: errors.New("error getting space"),
 				},
 			},

--- a/tags_test.go
+++ b/tags_test.go
@@ -18,24 +18,28 @@ type mockCFClientWrapper struct {
 	instanceGUID       string
 }
 
-func (m *mockCFClientWrapper) getOrganizationName(organizationGUID string) (string, error) {
+func (m *mockCFClientWrapper) getOrganization(organizationGUID string) (*resource.Organization, error) {
 	if m.getOrganizationErr != nil {
-		return "", m.getOrganizationErr
+		return nil, m.getOrganizationErr
 	}
 	if m.organizationGUID != "" && m.organizationGUID != organizationGUID {
-		return "", errors.New("organization GUID does not match expected value")
+		return nil, errors.New("organization GUID does not match expected value")
 	}
-	return m.organizationName, nil
+	return &resource.Organization{
+		Name: m.organizationName,
+	}, nil
 }
 
-func (m *mockCFClientWrapper) getSpaceName(spaceGUID string) (string, error) {
+func (m *mockCFClientWrapper) getSpace(spaceGUID string) (*resource.Space, error) {
 	if m.getSpaceErr != nil {
-		return "", m.getSpaceErr
+		return nil, m.getSpaceErr
 	}
 	if m.spaceGUID != "" && m.spaceGUID != spaceGUID {
-		return "", errors.New("space GUID does not match expected value")
+		return nil, errors.New("space GUID does not match expected value")
 	}
-	return m.spaceName, nil
+	return &resource.Space{
+		Name: m.spaceName,
+	}, nil
 }
 
 func (m *mockCFClientWrapper) getServiceInstance(instanceGUID string) (*resource.ServiceInstance, error) {
@@ -181,9 +185,9 @@ func TestGenerateTags(t *testing.T) {
 				test.action,
 				test.serviceOfferingName,
 				test.servicePlanName,
-				test.organizationGUID,
-				test.spaceGUID,
 				test.instanceGUID,
+				test.spaceGUID,
+				test.organizationGUID,
 			)
 
 			if err != nil {
@@ -208,22 +212,22 @@ func TestGenerateTagsHandleErrors(t *testing.T) {
 		tagManager  *CfTagManager
 		expectedErr error
 	}{
-		"error getting organization name": {
+		"error getting organization": {
 			tagManager: &CfTagManager{
 				cfNameResolver: &mockCFClientWrapper{
-					getOrganizationErr: errors.New("error getting organization name"),
+					getOrganizationErr: errors.New("error getting organization"),
 				},
 			},
-			expectedErr: errors.New("error getting organization name"),
+			expectedErr: errors.New("error getting organization"),
 		},
-		"error getting space name": {
+		"error getting space": {
 			tagManager: &CfTagManager{
 				broker: "AWS Broker",
 				cfNameResolver: &mockCFClientWrapper{
-					getSpaceErr: errors.New("error getting space name"),
+					getSpaceErr: errors.New("error getting space"),
 				},
 			},
-			expectedErr: errors.New("error getting space name"),
+			expectedErr: errors.New("error getting space"),
 		},
 	}
 


### PR DESCRIPTION
## Changes proposed in this pull request:

There's some pretty extensive refactoring in this PR, namely:

- Making the `environment` tag key came from a property on the `CFTagManager` struct rather than an argument to `GenerateTags`
- Rename `CFNameResolver` to `CFResourceGetter`
- Refactor `CFResourceGetter` functions to return the CF resource, not just the resource name
- In `GenerateTags`, add the ability to look up the space and org for an instance and thus set tags for them when `getMissingResources = true`. This helps in the context of a bind request to the broker, where there is no information about the space or org provided in the request, but we may still want to tag generated AWS resources with information about the org and space
- Refactor `GenerateTags` to accept a struct of GUIDs as `ResourceGUIDs` rather than separate positional arguments for each GUID
- Add/update unit tests

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

No security considerations, just refactoring how tags are generated for AWS resources
